### PR TITLE
Fixed bug setting shapekeys then exiting loop.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,13 +6,13 @@ from . import skw_props
 
 bl_info = {
     'name' : 'ShapeKeyWrap',
-    'author' : 'Mykyta Petrenko (Squeezy Pixels)',
-    'description' : 'Blender addon for transfering shapekeys from on mesh to another one using surface deform modifier.',
+    'author' : 'Mykyta Petrenko (Squeezy Pixels), edited by Valerie Snow ;3',
+    'description' : 'Furrified Blender addon for transfering shapekeys from on mesh to another one using surface deform modifier.',
     'blender' : (3, 00, 0),
-    'version' : (0, 4, 0),
+    'version' : (0, 5, 0),
     'location' : 'View3D > Object Mode > N-Panel > Tools > Shape Key Wrap',
     'warning' : '',
-    'doc_url': 'https://github.com/MykytaPetrenko/ShapeKeyWrap',
+    'doc_url': 'https://github.com/ValsnowUwU/FurryShapeKeyWrap/',
     'category': 'Mesh'
 }
 

--- a/skw_operators.py
+++ b/skw_operators.py
@@ -179,26 +179,26 @@ def skw_transfer_shape_keys(self, context: bpy.types.Context) -> None:
 def skw_poll_transfer_shapekeys(context: bpy.types.Context):
     active = context.active_object
     if active is None:
-        return False, 'Invalid source object'
+        return False, 'Invalid source object GRR!'
     if active.type != 'MESH':
-        return False, 'Non-mesh object is active'
+        return False, 'Select a mesh silly'
     if active.data.shape_keys is None or len(active.data.shape_keys.key_blocks) <= 1:
-        return False, 'Insufficient number of shapekeys'
+        return False, 'No shapekeys hewe is lonely'
 
     if len(context.selected_objects) < 2:
-        return False, 'No target object selected'
+        return False, 'Sewect a target objewct'
     obj_count = 0
     obj_name = ''
     for obj in context.selected_objects:
         if obj.type != 'MESH':
-            return False, 'Non-mesh object is selected'
+            return False, 'Select ONLY meshes silly grr'
         elif obj is not active:
             obj_count += 1
             obj_name = obj.name
     if obj_count == 1:
-        return True, f'From: {active.name}\nTo: {obj_name}'
+        return True, f'Fwom: {active.name}\nTo: {obj_name}'
     else:
-        return True, f'From: {active.name}\nTo: {obj_count} other objects'
+        return True, f'Fwom: {active.name}\nTo: {obj_count} other objects!!!'
 
 
 def skw_bind_shape_key_values(self, context: bpy.types.Context):
@@ -265,12 +265,12 @@ class SKW_OT_transfer_shape_keys(bpy.types.Operator):
         try:
             skw_transfer_shape_keys(self, context)
         except IsNotBoundException:
-            self.report({"ERROR"}, "Unable to bind surface deform modifier. Learn more from the addons github")
-            return {"CANCELLED"}
+            self.report({"ERROR"}, " Is beeeg pwoblem! Unable to bind surface deform modifier. Learn more from the addons github")
+            return {"CANCELLED cwy"}
         except Exception as ex:
             self.report({"ERROR"}, str(ex))
-            return {"CANCELLED"}
-        return {"FINISHED"}
+            return {"CANCELLED cwy"}
+        return {"FINISHED YAyyyy"}
 
 
 class SKW_OT_refresh_shape_keys(bpy.types.Operator):

--- a/skw_operators.py
+++ b/skw_operators.py
@@ -132,9 +132,10 @@ def skw_transfer_shape_keys(self, context: bpy.types.Context) -> None:
             # Skip temp noise shape key
             if sk.name == noise_key_name:
                 continue
-            sk.value = 1.0
             if skw.transfer_by_list and sk.name not in transfer_list:
                 continue
+            # Moved this back a few lines, to stop settting shapekeys and then exiting.
+            sk.value = 1.0
             deformer.name = sk.name
             if props.replace_shapekeys:
                 target_sks = target_obj.data.shape_keys

--- a/skw_operators.py
+++ b/skw_operators.py
@@ -266,11 +266,11 @@ class SKW_OT_transfer_shape_keys(bpy.types.Operator):
             skw_transfer_shape_keys(self, context)
         except IsNotBoundException:
             self.report({"ERROR"}, " Is beeeg pwoblem! Unable to bind surface deform modifier. Learn more from the addons github")
-            return {"CANCELLED cwy"}
+            return {"CANCELLED"}
         except Exception as ex:
             self.report({"ERROR"}, str(ex))
-            return {"CANCELLED cwy"}
-        return {"FINISHED YAyyyy"}
+            return {"CANCELLED"}
+        return {"FINISHED"}
 
 
 class SKW_OT_refresh_shape_keys(bpy.types.Operator):

--- a/skw_panel.py
+++ b/skw_panel.py
@@ -45,6 +45,9 @@ class SKT_PT_object_mode(bpy.types.Panel):
             if skw.bind_noise:
                 layout.prop(skw, 'min_noise', text='Min Noise')
                 layout.prop(skw, 'max_noise', text='Max Noise')
+            layout.prop(skw, 'delete_empty', text='Delete Empty')
+            if skw.delete_empty:
+                layout.prop(skw, 'empty_threshold', text='Threshold')
             layout.prop(skw, 'transfer_by_list', text='Transfur By The Lwist', toggle=True)
             col = layout.column(align=True)
             col.enabled = skw.transfer_by_list
@@ -61,7 +64,7 @@ class SKT_PT_object_mode(bpy.types.Panel):
 
         box = layout.box()
         col = box.column(align=True)
-        col.operator(SKW_OT_transfer_shape_keys.bl_idname, text='Transfer Shape Keys', icon='ARROW_LEFTRIGHT')
+        col.operator(SKW_OT_transfer_shape_keys.bl_idname, text='Transfur Shape Keys', icon='ARROW_LEFTRIGHT')
         col.operator(SKW_OT_bind_shape_key_values.bl_idname, text='Bind Valuwues', icon='DRIVER')
 
 

--- a/skw_panel.py
+++ b/skw_panel.py
@@ -18,7 +18,7 @@ class SKT_PT_object_mode(bpy.types.Panel):
     """
     Addon main menu (N-Panel)
     """
-    bl_label = 'Shape Key Wrap'
+    bl_label = 'Shape Key Wrap UwU'
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = 'Tools'
@@ -45,7 +45,7 @@ class SKT_PT_object_mode(bpy.types.Panel):
             if skw.bind_noise:
                 layout.prop(skw, 'min_noise', text='Min Noise')
                 layout.prop(skw, 'max_noise', text='Max Noise')
-            layout.prop(skw, 'transfer_by_list', text='Transfer By The List', toggle=True)
+            layout.prop(skw, 'transfer_by_list', text='Transfur By The Lwist', toggle=True)
             col = layout.column(align=True)
             col.enabled = skw.transfer_by_list
             col.template_list(
@@ -54,15 +54,15 @@ class SKT_PT_object_mode(bpy.types.Panel):
                 skw, 'shape_key_index',
                 rows=5
             )
-            col.operator(SKW_OT_refresh_shape_keys.bl_idname, text='Refresh').action = 'REFRESH'
+            col.operator(SKW_OT_refresh_shape_keys.bl_idname, text='Refwesh').action = 'REFRESH'
             row = col.row(align=True)
-            row.operator(SKW_OT_refresh_shape_keys.bl_idname, text='Check All').action = 'CHECK_ALL'
-            row.operator(SKW_OT_refresh_shape_keys.bl_idname, text='Uncheck All').action = 'UNCHECK_ALL'
+            row.operator(SKW_OT_refresh_shape_keys.bl_idname, text='Sewect All').action = 'CHECK_ALL'
+            row.operator(SKW_OT_refresh_shape_keys.bl_idname, text='Unsewect All').action = 'UNCHECK_ALL'
 
         box = layout.box()
         col = box.column(align=True)
         col.operator(SKW_OT_transfer_shape_keys.bl_idname, text='Transfer Shape Keys', icon='ARROW_LEFTRIGHT')
-        col.operator(SKW_OT_bind_shape_key_values.bl_idname, text='Bind Values', icon='DRIVER')
+        col.operator(SKW_OT_bind_shape_key_values.bl_idname, text='Bind Valuwues', icon='DRIVER')
 
 
 classes = [SKT_PT_object_mode, SKT_UL_items]

--- a/skw_props.py
+++ b/skw_props.py
@@ -14,6 +14,9 @@ class SKW_Property(bpy.types.PropertyGroup):
     min_noise: bpy.props.FloatProperty(default=-0.0001, precision=5)
     max_noise: bpy.props.FloatProperty(default=0.0001, precision=5)
 
+    delete_empty: bpy.props.BoolProperty(default=False)
+    empty_threshold: bpy.props.FloatProperty(default=0.00001, precision=5)
+
     def refresh_shape_keys(self, mesh, default=None):
         old_values = dict()
         for sk in self.shape_keys_to_transfer:


### PR DESCRIPTION
Fixed a bug that set shapekeys, then continued the loop if they were not in the transfer list.
Moved "sk.value = 1.0" down 3 lines. So it happens after checking if it's in the transfer list.